### PR TITLE
Don't wrap Algorithm if already implements ScreenBasedAlgorithm

### DIFF
--- a/library/src/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/com/google/maps/android/clustering/ClusterManager.java
@@ -111,7 +111,11 @@ public class ClusterManager<T extends ClusterItem> implements
     }
 
     public void setAlgorithm(Algorithm<T> algorithm) {
-        setAlgorithm(new ScreenBasedAlgorithmAdapter<T>(algorithm));
+        if (algorithm instanceof ScreenBasedAlgorithm) {
+            setAlgorithm((ScreenBasedAlgorithm) algorithm);
+        } else {
+            setAlgorithm(new ScreenBasedAlgorithmAdapter<T>(algorithm));
+        }
     }
 
     public void setAlgorithm(ScreenBasedAlgorithm<T> algorithm) {


### PR DESCRIPTION
If an Algorithm reference is already a ScreenBasedAlgorithm, then it can be passed as is to setAlgorithm(ScreenBasedAlgorithm). Only if it is not already a ScreenBasedAlgorithm is it then wrapped with a ScreenBasedAlgorithmAdapter.