### PR TITLE
do not recluster when showing cluster info window

### DIFF
--- a/library/src/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/com/google/maps/android/clustering/ClusterManager.java
@@ -46,7 +46,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public class ClusterManager<T extends ClusterItem> implements
         GoogleMap.OnCameraIdleListener,
         GoogleMap.OnMarkerClickListener,
-        GoogleMap.OnInfoWindowClickListener {
+        GoogleMap.OnInfoWindowClickListener,
+        GoogleMap.OnInfoWindowCloseListener {
 
     private final MarkerManager mMarkerManager;
     private final MarkerManager.Collection mMarkers;
@@ -218,14 +219,20 @@ public class ClusterManager<T extends ClusterItem> implements
 
         // Don't re-compute clusters if the map has just been panned/tilted/rotated.
         } else if (mPreviousCameraPosition == null || mPreviousCameraPosition.zoom != mMap.getCameraPosition().zoom) {
-            mPreviousCameraPosition = mMap.getCameraPosition();
             cluster();
         }
+        mPreviousCameraPosition = mMap.getCameraPosition();
     }
 
     @Override
     public boolean onMarkerClick(Marker marker) {
+        mAlgorithm.setShouldReclusterOnMapMovement(false);
         return getMarkerManager().onMarkerClick(marker);
+    }
+
+    @Override
+    public void onInfoWindowClose(final Marker marker) {
+        mAlgorithm.setShouldReclusterOnMapMovement(true);
     }
 
     @Override

--- a/library/src/com/google/maps/android/clustering/ClusterManager.java
+++ b/library/src/com/google/maps/android/clustering/ClusterManager.java
@@ -226,8 +226,11 @@ public class ClusterManager<T extends ClusterItem> implements
 
     @Override
     public boolean onMarkerClick(Marker marker) {
-        mAlgorithm.setShouldReclusterOnMapMovement(false);
-        return getMarkerManager().onMarkerClick(marker);
+        final boolean markerClick = getMarkerManager().onMarkerClick(marker);
+        if (!markerClick) {
+            mAlgorithm.setShouldReclusterOnMapMovement(false);
+        }
+        return markerClick;
     }
 
     @Override

--- a/library/src/com/google/maps/android/clustering/algo/NonHierarchicalViewBasedAlgorithm.java
+++ b/library/src/com/google/maps/android/clustering/algo/NonHierarchicalViewBasedAlgorithm.java
@@ -41,6 +41,8 @@ public class NonHierarchicalViewBasedAlgorithm<T extends ClusterItem>
 
     private LatLng mMapCenter;
 
+    private boolean shouldReclusterOnMapMovement = true;
+
     public NonHierarchicalViewBasedAlgorithm(int screenWidth, int screenHeight) {
         mViewWidth = screenWidth;
         mViewHeight = screenHeight;
@@ -58,7 +60,7 @@ public class NonHierarchicalViewBasedAlgorithm<T extends ClusterItem>
 
     @Override
     public boolean shouldReclusterOnMapMovement() {
-        return true;
+        return shouldReclusterOnMapMovement;
     }
 
     /**
@@ -70,6 +72,10 @@ public class NonHierarchicalViewBasedAlgorithm<T extends ClusterItem>
     public void updateViewSize(int width, int height) {
         mViewWidth = width;
         mViewHeight = height;
+    }
+
+    public void setShouldReclusterOnMapMovement(final boolean shouldReclusterOnMapMovement) {
+        this.shouldReclusterOnMapMovement = shouldReclusterOnMapMovement;
     }
 
     private Bounds getVisibleBounds(int zoom) {

--- a/library/src/com/google/maps/android/clustering/algo/ScreenBasedAlgorithm.java
+++ b/library/src/com/google/maps/android/clustering/algo/ScreenBasedAlgorithm.java
@@ -28,4 +28,6 @@ import com.google.maps.android.clustering.ClusterItem;
 public interface ScreenBasedAlgorithm<T extends ClusterItem> extends Algorithm<T>, GoogleMap.OnCameraChangeListener {
 
     boolean shouldReclusterOnMapMovement();
+
+    void setShouldReclusterOnMapMovement(boolean shouldReclusterOnMapMovement);
 }

--- a/library/src/com/google/maps/android/clustering/algo/ScreenBasedAlgorithmAdapter.java
+++ b/library/src/com/google/maps/android/clustering/algo/ScreenBasedAlgorithmAdapter.java
@@ -36,6 +36,10 @@ public class ScreenBasedAlgorithmAdapter<T extends ClusterItem> implements Scree
         return false;
     }
 
+    public void setShouldReclusterOnMapMovement(final boolean shouldReclusterOnMapMovement) {
+        // always do not recluster
+    }
+
     @Override
     public void addItem(T item) {
         mAlgorithm.addItem(item);


### PR DESCRIPTION
I noticed that NonHierarchicalViewBasedAlgorithm.shouldReclusterOnMapMovement() always return true, causing recluster on map movement even if it is just centering at selected cluster.
So when user taps at cluster to see info window it is shown only for a second, then disappear.

This solution allows to diasble clustering when showing info window, but cluster manager should also process infoWindowClose.